### PR TITLE
Add required parameter "BAT0" to batteryInfo call in example.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -71,7 +71,7 @@ the batterywidget.
 
 *awesome < 3.5*
 ```lua
-  batterywidget.text = batteryInfo
+  batterywidget.text = batteryInfo("BAT0")
 ```
 
 *awesome >= 3.5*


### PR DESCRIPTION
This may seem pedantic but for the uninitiated (like me) this will save a bit of time / debugging.

Signed-off-by: Philip Tricca <flihp@twobit.us>
