### PR TITLE
Fix "too many open files" bug on awesome 4.0

### DIFF
--- a/battery.lua
+++ b/battery.lua
@@ -50,6 +50,9 @@ function batteryInfo(adapter)
       icon = ""
       percent = ""
     end
+
+    -- fix 'too many open files' bug on awesome 4.0
+    fh:close()
   end
   return " "..icon..battery..percent.." "
 end


### PR DESCRIPTION
On my Arch Linux when I use awesome battery widget for about an hour after boot awesome stops responding to my hotkey, and Super+R or Super+P application menu stops working, a error notice said "too many open files". After examining the code I found that in function `batteryInfo` if `fh` is valid it is **NOT** closed when the function ends, so I added this line.

What is strange is that this error doesn't occur when I use awesome 3.5.